### PR TITLE
Allow multiple winners and check membership

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -50,6 +50,7 @@ DROP TABLE IF EXISTS exec_positions;
 CREATE TABLE exec_positions (
 	id INTEGER PRIMARY KEY,
 	title TEXT NOT NULL,
+	num_winners INTEGER NOT NULL,
 	open BOOLEAN NOT NULL
 );
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -219,6 +219,14 @@ pub fn election_vote(
         );
     }
 
+    if !user.is_barbell_member() {
+        // Redirect to the main elections page
+        return Flash::error(
+            Redirect::to(uri!(frontend::elections)),
+            "You are not a Barbell member, so you cannot vote in this election.",
+        );
+    }
+
     // Check all the votes are unique
     let all_unique = data.values().unique().count() == data.values().count();
 

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -300,10 +300,10 @@ pub fn election_results(
     }
 
     // Get all the available positions
-    let positions: BTreeMap<i32, String> = schema::ExecPosition::get_results(&conn.0)
+    let positions: BTreeMap<i32, schema::ExecPosition> = schema::ExecPosition::get_results(&conn.0)
         .unwrap()
         .into_iter()
-        .map(|pos| (pos.id, pos.title))
+        .map(|pos| (pos.id, pos))
         .collect();
 
     // Map all the nominees from `warwick_id` -> `name`
@@ -345,7 +345,8 @@ pub fn election_results(
             let voter_count = map.len();
             let collected: Vec<_> = map.values().map(Vec::clone).collect();
 
-            let mut tally: Tally<i32, f64> = Tally::new(1, Quota::Hagenbach);
+            let num_winners = positions[position_id].num_winners as u32;
+            let mut tally: Tally<i32, f64> = Tally::new(num_winners, Quota::Hagenbach);
 
             for vote in &collected {
                 tally.add_ref(vote);
@@ -365,7 +366,7 @@ pub fn election_results(
             };
 
             context::ElectionResult {
-                title: positions[position_id].clone(),
+                title: positions[position_id].title.clone(),
                 winner: outcome.0,
                 tie: outcome.1,
                 voter_count,

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -267,6 +267,14 @@ pub fn election_voting(
         ));
     }
 
+    if !user.is_barbell_member() {
+        // Redirect to the main elections page
+        return Err(Flash::error(
+            Redirect::to(uri!(elections)),
+            "You are not a Barbell member, so you cannot vote in this election.",
+        ));
+    }
+
     let mut nominations = schema::Nomination::for_position(position_id, &conn.0).unwrap();
     let message = flash.map(context::Message::from);
     let current_ballot = schema::Vote::get_current_ballot(user.id, position_id, &conn.0).unwrap();

--- a/src/guards.rs
+++ b/src/guards.rs
@@ -44,6 +44,19 @@ impl AuthorisedUser {
             .find(|v| i32::from_str(v) == Ok(self.id))
             .is_some()
     }
+
+    /// Returns true if the user is a member of the club.
+    pub fn is_barbell_member(&self) -> bool {
+        // Get the environment variable and parse it
+        let var = match env::var("BARBELL_MEMBERS") {
+            Ok(value) => value,
+            Err(_) => return false,
+        };
+
+        var.split(',')
+            .find(|v| i32::from_str(v) == Ok(self.id))
+            .is_some()
+    }
 }
 
 impl<'a, 'r> FromRequest<'a, 'r> for AuthorisedUser {

--- a/src/schema/exec_position.rs
+++ b/src/schema/exec_position.rs
@@ -9,6 +9,8 @@ table! {
         id -> Integer,
         /// The name of the position.
         title -> Text,
+        /// The number of people who can win in this position
+        num_winners -> Integer,
         /// Whether voting is open for this position or not.
         open -> Bool,
     }
@@ -21,6 +23,8 @@ pub struct ExecPosition {
     pub id: i32,
     /// The title of the position
     pub title: String,
+    /// The number of people who can win in this position
+    pub num_winners: i32,
     /// Whether voting is open for this position or not
     pub open: bool,
 }


### PR DESCRIPTION
Allow multiple candidates to win an election (in the case of social secretaries) and check users are members prior to voting.