### PR TITLE
feat: run migrations on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,10 @@
-#[rocket::main]
-async fn main() {
-    setup();
+use std::collections::HashMap;
+use std::env;
 
-    blackboards::build_rocket()
-        .launch()
-        .await
-        .expect("Failed to launch");
-}
+use rocket::figment::{providers::Env, Figment};
+use rocket::Config;
+use sqlx::migrate::Migrator;
+use sqlx::PgPool;
 
 /// Runs the setup for the server.
 ///
@@ -23,4 +21,52 @@ fn setup() {
     tracing_subscriber::fmt::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .init();
+}
+
+/// Builds the configuration for the Rocket instance.
+fn config_from_env() -> Figment {
+    let mut databases = HashMap::new();
+    let mut urls = HashMap::new();
+
+    let database_url =
+        env::var("DATABASE_URL").expect("Failed to find `DATABASE_URL` in the environment");
+
+    urls.insert("url", database_url);
+    databases.insert("blackboards", urls);
+
+    Figment::from(Config::default())
+        .merge(Env::prefixed("ROCKET_").global())
+        .merge(("log_level", "off"))
+        .merge(("databases", databases))
+}
+
+async fn run_migrations(database_url: &str) -> sqlx::Result<()> {
+    let pool = PgPool::connect(database_url).await?;
+
+    static MIGRATOR: Migrator = sqlx::migrate!();
+    MIGRATOR.run(&pool).await?;
+
+    Ok(())
+}
+
+#[rocket::main]
+async fn main() {
+    setup();
+
+    let config = config_from_env();
+
+    let value = config
+        .find_value("databases.blackboards.url")
+        .expect("Failed to find value in the configuration");
+
+    let database_url = value.as_str().expect("Config value was not a string");
+
+    run_migrations(database_url)
+        .await
+        .expect("Failed to run migrations");
+
+    blackboards::build_rocket(config)
+        .launch()
+        .await
+        .expect("Failed to launch");
 }


### PR DESCRIPTION
`fisherman` supported running pre-commands before the binary started up, allowing us to use `sqlx migrate run` beforehand. Kubernetes doesn't support this, so we need to run the migrations when the service starts up instead.
